### PR TITLE
[Support] update to kethereum 0.76.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.3.41'
-        kotlin_serialization_version = '0.11.1'
-        coroutines_version = "1.2.2"
+        kotlin_version = '1.3.50'
+        kotlin_serialization_version = '0.12.0'
+        coroutines_version = "1.3.0"
 
         junit_version = "4.12"
         mockk_version = "1.9.3"
@@ -17,8 +17,9 @@ buildscript {
         okhttp_version = "3.14.1"
 
         spongycastle_version = "1.58.0.0"
-        kmnid_version = "0.3.2"
-        kethereum_version = "0.75.1"
+        kmnid_version = "0.4.0"
+        kethereum_version = "0.76.1"
+        khex_version = "1.0.0-RC3"
 
         current_release_version = "0.1.2"
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    api "com.squareup.okhttp3:okhttp:$okhttp_version"
+    implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
     implementation "com.madgag.spongycastle:core:$spongycastle_version"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,9 +11,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     api "com.squareup.okhttp3:okhttp:$okhttp_version"
-    api "com.github.uport-project:kmnid:$kmnid_version"
-    implementation "com.github.komputing.KEthereum:functions:$kethereum_version"
-    implementation "com.github.komputing.KEthereum:crypto:$kethereum_version"
     implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
     implementation "com.madgag.spongycastle:core:$spongycastle_version"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,11 +5,6 @@ apply plugin: "com.jfrog.bintray"
 
 project.ext.description = "core class definitions of the uPort kotlin SDK"
 
-//XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
-configurations.all {
-    exclude group: "com.github.walleth"
-}
-
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -17,8 +12,9 @@ dependencies {
 
     api "com.squareup.okhttp3:okhttp:$okhttp_version"
     api "com.github.uport-project:kmnid:$kmnid_version"
-    api "com.github.komputing.KEthereum:functions:$kethereum_version"
-    api "com.github.komputing.KEthereum:crypto:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:functions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:crypto:$kethereum_version"
+    implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
     implementation "com.madgag.spongycastle:core:$spongycastle_version"
 
     testImplementation "junit:junit:$junit_version"

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -2,7 +2,6 @@
 
 package me.uport.sdk.core
 
-import me.uport.mnid.MNID
 import org.komputing.khex.extensions.clean0xPrefix
 import org.komputing.khex.extensions.prepend0xPrefix
 
@@ -31,7 +30,8 @@ object Networks {
                 rpcUrl = "https://mainnet.infura.io/v3/e72b472993ff46d3b5b88faa47214d7f",
                 ethrDidRegistry = DEFAULT_ERC1056_REGISTRY,
                 explorerUrl = "https://etherscan.io",
-                uPortRegistry = MNID.encode(mainnetId, "0xab5c8051b9a1df1aab0149f8b0630848b7ecabf6"),
+                // MNID.encode(mainnetId, "0xab5c8051b9a1df1aab0149f8b0630848b7ecabf6"),
+                uPortRegistry = "2ngV6QowStW3ebKXYUhy43wCqeLXcuTfHj2",
                 faucetUrl = defaultFaucetUrl,
                 relayUrl = defaultTxRelayUrl,
                 txRelayAddress = "0xec2642cd5a47fd5cca2a8a280c3b5f88828aa578"
@@ -44,7 +44,8 @@ object Networks {
                 rpcUrl = "https://rinkeby.infura.io/v3/e72b472993ff46d3b5b88faa47214d7f",
                 ethrDidRegistry = DEFAULT_ERC1056_REGISTRY,
                 explorerUrl = "https://rinkeby.etherscan.io",
-                uPortRegistry = MNID.encode(rinkebyId, "0x2cc31912b2b0f3075a87b3640923d45a26cef3ee"),
+                //MNID.encode(rinkebyId, "0x2cc31912b2b0f3075a87b3640923d45a26cef3ee"),
+                uPortRegistry = "2ogxWTKKfy6kwfqdgdEE6GCdoFD4vm4YRZe",
                 faucetUrl = "https://api.uport.me/sensui/fund/",
                 relayUrl = "https://api.uport.me/sensui/relay/",
                 txRelayAddress = "0xda8c6dce9e9a85e6f9df7b09b2354da44cb48331"
@@ -57,7 +58,8 @@ object Networks {
                 rpcUrl = "https://ropsten.infura.io/v3/e72b472993ff46d3b5b88faa47214d7f",
                 ethrDidRegistry = DEFAULT_ERC1056_REGISTRY,
                 explorerUrl = "https://ropsten.etherscan.io",
-                uPortRegistry = MNID.encode(ropstenId, "0x41566e3a081f5032bdcad470adb797635ddfe1f0"),
+                //MNID.encode(ropstenId, "0x41566e3a081f5032bdcad470adb797635ddfe1f0"),
+                uPortRegistry = "2oKVhUttUcwaFAopRBGA21NDJoYcBb3a6iz",
                 faucetUrl = defaultFaucetUrl,
                 relayUrl = defaultTxRelayUrl,
                 txRelayAddress = "0xa5e04cf2942868f5a66b9f7db790b8ab662039d5"
@@ -70,7 +72,8 @@ object Networks {
                 rpcUrl = "https://kovan.infura.io/v3/e72b472993ff46d3b5b88faa47214d7f",
                 ethrDidRegistry = DEFAULT_ERC1056_REGISTRY,
                 explorerUrl = "https://kovan.etherscan.io",
-                uPortRegistry = MNID.encode(kovanId, "0x5f8e9351dc2d238fb878b6ae43aa740d62fc9758"),
+                //MNID.encode(kovanId, "0x5f8e9351dc2d238fb878b6ae43aa740d62fc9758"),
+                uPortRegistry = "354S1QuCzkmKoQ3ADSLp1KtqAe8gZ74F9am",
                 faucetUrl = defaultFaucetUrl,
                 relayUrl = defaultTxRelayUrl,
                 txRelayAddress = "0xa9235151d3afa7912e9091ab76a36cbabe219a0c"

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -3,8 +3,8 @@
 package me.uport.sdk.core
 
 import me.uport.mnid.MNID
-import org.walleth.khex.clean0xPrefix
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 
 /**
  * Convenience singleton that holds URLs and addresses for different eth networks.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -17,10 +17,10 @@ dependencies {
 
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
 
-    api "com.github.komputing.KEthereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:extensions:$kethereum_version"
     implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
 
-    api project(":core")
+    implementation project(":core")
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -11,11 +11,6 @@ compileKotlin {
     }
 }
 
-//XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
-configurations.all {
-    exclude group: "com.github.walleth"
-}
-
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
@@ -26,6 +21,7 @@ dependencies {
     api "com.github.komputing.KEthereum:rlp:$kethereum_version"
     api "com.github.komputing.KEthereum:functions:$kethereum_version"
     api "com.github.komputing.KEthereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
 
     api project(":core")
 

--- a/jsonrpc/build.gradle
+++ b/jsonrpc/build.gradle
@@ -17,9 +17,6 @@ dependencies {
 
     implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
 
-    api "com.github.komputing.KEthereum:model:$kethereum_version"
-    api "com.github.komputing.KEthereum:rlp:$kethereum_version"
-    api "com.github.komputing.KEthereum:functions:$kethereum_version"
     api "com.github.komputing.KEthereum:extensions:$kethereum_version"
     implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
 

--- a/jsonrpc/src/main/java/me/uport/sdk/jsonrpc/JsonRPC.kt
+++ b/jsonrpc/src/main/java/me/uport/sdk/jsonrpc/JsonRPC.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.Types
 import me.uport.sdk.core.HttpClient
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 import java.io.IOException
 import java.lang.reflect.ParameterizedType
 import java.math.BigInteger

--- a/jsonrpc/src/main/java/me/uport/sdk/jsonrpc/JsonRPCBase.kt
+++ b/jsonrpc/src/main/java/me/uport/sdk/jsonrpc/JsonRPCBase.kt
@@ -9,7 +9,7 @@ import com.squareup.moshi.ToJson
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.kethereum.extensions.maybeHexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 import java.math.BigInteger
 
 

--- a/signer-common/build.gradle
+++ b/signer-common/build.gradle
@@ -5,18 +5,16 @@ apply plugin: "com.jfrog.bintray"
 
 project.ext.description = "Signer interface and default implementation for uPort kotlin SDK"
 
-//XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
-configurations.all {
-    exclude group: "com.github.walleth"
-}
-
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
     api project(":core")
+    implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
     api "com.github.komputing.KEthereum:extensions:$kethereum_version"
+    api "com.github.komputing.KEthereum:functions:$kethereum_version"
+    api "com.github.komputing.KEthereum:crypto:$kethereum_version"
     api "com.github.komputing.KEthereum:model:$kethereum_version"
     api "com.github.komputing.KEthereum:hashes:$kethereum_version"
     implementation "com.madgag.spongycastle:core:$spongycastle_version"

--- a/signer-common/build.gradle
+++ b/signer-common/build.gradle
@@ -10,15 +10,15 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 
-    api project(":core")
+    implementation project(":core")
     implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
-    api "com.github.komputing.KEthereum:extensions:$kethereum_version"
-    api "com.github.komputing.KEthereum:functions:$kethereum_version"
-    api "com.github.komputing.KEthereum:crypto:$kethereum_version"
-    api "com.github.komputing.KEthereum:model:$kethereum_version"
-    api "com.github.komputing.KEthereum:hashes:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:functions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:crypto:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:model:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:hashes:$kethereum_version"
     implementation "com.madgag.spongycastle:core:$spongycastle_version"
-    api "com.github.komputing.KEthereum:crypto_impl_spongycastle:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:crypto_impl_spongycastle:$kethereum_version"
 
 
     testImplementation "junit:junit:$junit_version"

--- a/signer-common/src/main/java/me/uport/sdk/signer/Extensions.kt
+++ b/signer-common/src/main/java/me/uport/sdk/signer/Extensions.kt
@@ -11,18 +11,16 @@ import org.kethereum.extensions.toBigInteger
 import org.kethereum.extensions.toBytesPadded
 import org.kethereum.extensions.toHexStringNoPrefix
 import org.kethereum.model.*
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
+import org.komputing.khex.extensions.toNoPrefixHexString
 import org.spongycastle.asn1.ASN1EncodableVector
 import org.spongycastle.asn1.ASN1Encoding
 import org.spongycastle.asn1.ASN1Integer
 import org.spongycastle.asn1.DERSequence
-import org.walleth.khex.clean0xPrefix
-import org.walleth.khex.prepend0xPrefix
-import org.walleth.khex.toNoPrefixHexString
 import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 import java.nio.charset.Charset
-import java.util.*
-
 
 /**
  * Converts a hex string to another hex string pre-padded with zeroes until it represents at least 32 bytes
@@ -89,7 +87,7 @@ fun SignatureData.getJoseEncoded(recoverable: Boolean = false): String {
     bos.write(this.r.toBytesPadded(SIG_COMPONENT_SIZE))
     bos.write(this.s.toBytesPadded(SIG_COMPONENT_SIZE))
     if (recoverable) {
-        bos.write(byteArrayOf((this.v - 27).toByte()))
+        bos.write(byteArrayOf((this.v.toByte() - 27).toByte()))
     }
     return bos.toByteArray().toBase64UrlSafe()
 }
@@ -105,15 +103,15 @@ fun String.decodeJose(recoveryParam: Byte = 27): SignatureData = this.decodeBase
  * @param recoveryParam can be used in case the signature is non recoverable to be added as recovery byte
  */
 fun ByteArray.decodeJose(recoveryParam: Byte = 27): SignatureData {
-    val rBytes = Arrays.copyOfRange(this, 0, SIG_COMPONENT_SIZE)
-    val sBytes = Arrays.copyOfRange(this, SIG_COMPONENT_SIZE, SIG_SIZE)
+    val rBytes = this.copyOfRange(0, SIG_COMPONENT_SIZE)
+    val sBytes = this.copyOfRange(SIG_COMPONENT_SIZE, SIG_SIZE)
     val v = if (this.size > SIG_SIZE)
         this[SIG_SIZE].let {
             if (it < 27) (it + 27).toByte() else it
         }
     else
         recoveryParam
-    return SignatureData(BigInteger(1, rBytes), BigInteger(1, sBytes), v)
+    return SignatureData(BigInteger(1, rBytes), BigInteger(1, sBytes), v.toInt().toBigInteger())
 }
 
 /**

--- a/signer-common/src/main/java/me/uport/sdk/signer/Extensions.kt
+++ b/signer-common/src/main/java/me/uport/sdk/signer/Extensions.kt
@@ -117,6 +117,7 @@ fun ByteArray.decodeJose(recoveryParam: Byte = 27): SignatureData {
 /**
  * Returns the DER encoding of the standard signature components
  */
+@Deprecated("This method will be removed in the next major release")
 fun SignatureData.getDerEncoded(): String {
 
     val v = ASN1EncodableVector()

--- a/signer-common/src/test/java/me/uport/sdk/signer/KPSignerTests.kt
+++ b/signer-common/src/test/java/me/uport/sdk/signer/KPSignerTests.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.SignatureData
-import org.walleth.khex.hexToByteArray
+import org.komputing.khex.extensions.hexToByteArray
 
 class KPSignerTests {
 
@@ -17,7 +17,7 @@ class KPSignerTests {
         val expectedSignature = SignatureData(
             r = "809e3b5ef25f4a3b039139e2fb70f70b636eba89c77a3b01e0c71c1a36d84126".hexToBigInteger(),
             s = "38524dfcd3e412cb6bc37f4594bbad104b6764bb14c64e42c699730106d1885a".hexToBigInteger(),
-            v = 28.toByte()
+            v = 28.toBigInteger()
         )
 
         val rawTransactionBytes =
@@ -38,7 +38,7 @@ class KPSignerTests {
         val referenceSignature = SignatureData(
             r = "6bcd81446183af193ca4a172d5c5c26345903b24770d90b5d790f74a9dec1f68".hexToBigInteger(),
             s = "e2b85b3c92c9b4f3cf58de46e7997d8efb6e14b2e532d13dfa22ee02f3a43d5d".hexToBigInteger(),
-            v = 28.toByte()
+            v = 28.toBigInteger()
         )
 
         val signer = KPSigner("65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960")
@@ -55,7 +55,7 @@ class KPSignerTests {
         val expectedSignature = SignatureData(
             r = "809e3b5ef25f4a3b039139e2fb70f70b636eba89c77a3b01e0c71c1a36d84126".hexToBigInteger(),
             s = "38524dfcd3e412cb6bc37f4594bbad104b6764bb14c64e42c699730106d1885a".hexToBigInteger(),
-            v = 28.toByte()
+            v = 28.toBigInteger()
         )
 
         val rawTransactionBytes =
@@ -74,7 +74,7 @@ class KPSignerTests {
         val referenceSignature = SignatureData(
             r = "6bcd81446183af193ca4a172d5c5c26345903b24770d90b5d790f74a9dec1f68".hexToBigInteger(),
             s = "e2b85b3c92c9b4f3cf58de46e7997d8efb6e14b2e532d13dfa22ee02f3a43d5d".hexToBigInteger(),
-            v = 28.toByte()
+            v = 28.toBigInteger()
         )
 
         val signer = KPSigner("65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960")

--- a/signer-common/src/test/java/me/uport/sdk/signer/SignatureTests.kt
+++ b/signer-common/src/test/java/me/uport/sdk/signer/SignatureTests.kt
@@ -43,7 +43,7 @@ class SignatureTests {
             address = "0xf34e6ddffedec32f759641552634f8b0df9c66a8",
             jwtSig = "3Br7BEdZwSaX8wNBxBnJvDWDwlfjPhtP3LSR95J7p4QpZ_bhqXIIJIkZdU29a7F-A9CQRkTPVUGCWvGHJ2VUDAE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x4e2c81b13fabada80ab446f27aee63d2cdd405dd4c8353e16ae59ccf5f05a91e".hexToBigInteger(),
                 s = "0x1fadfafcddfe2466c5f1597acff0a36ac0391f58251160fc2580fe50e4fcce7d".hexToBigInteger()
             )
@@ -53,7 +53,7 @@ class SignatureTests {
             address = "0xa998c6074b5cc04fcd775303e0f9a61ca535f35e",
             jwtSig = "2AqNpkt89PyW0mfg80sJZ5EpVVrVS88iAX-VvbWvJIhWXD3o45-9cDl_PxDJaRGYUMQXpNrji4dPLO2rQO8MJQA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x3d3b145bf1bcfded000705c855903f5c73382430d07cb482b2debe318e3d2236".hexToBigInteger(),
                 s = "0x215c48b00b745e7d81a1cd23e95f2ea1db3ec19b47ecb97005bb6929091585f3".hexToBigInteger()
             )
@@ -63,7 +63,7 @@ class SignatureTests {
             address = "0x7824fa28d444c250c0902fefd6c832fa88972db2",
             jwtSig = "-wYyGYTgY_gSZGwwHg2pdu18qiqMtFh9x4nFPfCdaGhTb_GniZbo6GUb0xs1YvO0pO-fFuq4r5YUYcjbrAmbTAA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x63ad50820d43370263edd71db5dbe77e99a2cfed94465068f94201c4957956bc".hexToBigInteger(),
                 s = "0x3ece112fad5fca89ba6a45578bae496987909c04cc70a82b8e64b95bc20a5774".hexToBigInteger()
             )
@@ -73,7 +73,7 @@ class SignatureTests {
             address = "0x8ac0e83a1b492bbdfd0da7a1048351a5b066249b",
             jwtSig = "fcjKhN9m2HagKPb8fh5sMsldOt-GXt4GlfRiIDnhFIvOuWQVhVJyBbrkRbN8SmoeQ2mNkBhHm1PhT3DHWzEorAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xcbfbbda3fa85865168b63ad281afba32b4e78a5c7eda4286915e9fe521403d45".hexToBigInteger(),
                 s = "0x1d3c5759c77e46004bcc13d3aae956f456cf15d6546ab4522f2b33c8f4554ea3".hexToBigInteger()
             )
@@ -83,7 +83,7 @@ class SignatureTests {
             address = "0xfb643e22564cb6cfdf7677a610348c172b83bc7b",
             jwtSig = "CxVQYUF_9radbcDNFCbg3142xZ6YRnlc3c6bVUX3diyzVmQzXL_gLdw-AeryZF3AyOlkf17TOXYS3pIXoW48TAE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x3f35e463828a480f544eab85e52e96f85cc4f6329e206397756a1ac217c33076".hexToBigInteger(),
                 s = "0x5eceee439b69d1d8e4a381dcabad526840d84bec36fc746e8ae04d5f0d327413".hexToBigInteger()
             )
@@ -93,7 +93,7 @@ class SignatureTests {
             address = "0x4ca3a9e0fd60bcfdd87681978bd6ab90e73b0832",
             jwtSig = "-JaIQk8QIoUBSgLFpzPR0BLcN852zcB36zg4OKgSs_9lZXV-U5kK1GczXTihHhj8VoowdlSYj2HB58WKfD_uoAE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x7e6d110cd8254761472939eccbcbffe0cf3585beab38a358b792f218ce7db387".hexToBigInteger(),
                 s = "0x68258a0829dafcf68bd275140a9793fb92e11987756c2cb266f8df556bb7b055".hexToBigInteger()
             )
@@ -103,7 +103,7 @@ class SignatureTests {
             address = "0xf138e67af6783c1e29032dd095f9d836b05fe581",
             jwtSig = "aLXtuFa1LsRV2JyPckvlEJRbPh2qTIlUVk2dRyIT2JnoV01tFO3MfaMn_uW8ahYW-9wiCemfA-4yJAUB6H93PwA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x3855e3c71feef2d4c0d70f868e6e293ec21cb53f641479eacdcac9906e8cb358".hexToBigInteger(),
                 s = "0x60492218184b5c5519ad2050605efd12cd59d132258adab9b02a1b4ea73490ef".hexToBigInteger()
             )
@@ -113,7 +113,7 @@ class SignatureTests {
             address = "0x69ff45046756ddb98d61f392056b3d04e32d8bd4",
             jwtSig = "mZspCm8ml4c0wP28H-mpZY0RQby42ZteHsvQ3osXObjGV8XckL_FzFY6leSnpiDF_iCCp390NSyEe7sfGeN3_QA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xcf3eac72eafedeb56b2ee646c27551cbdd437a652f6b74e38b31baafd764bd67".hexToBigInteger(),
                 s = "0x7f8f899ef5292306a0a39673faccae8267697cc86ce3f397f4c710636d50cdb7".hexToBigInteger()
             )
@@ -123,7 +123,7 @@ class SignatureTests {
             address = "0x674ba15dfd54b3e48f7134a246eb33a1202f31e3",
             jwtSig = "BgFYvqekFZXmit58E6YyTOi7rkz9pXqY6B8Ly1lv-uA3eEAS-ajHbf5O3BHn8kKCTwRX7ObdZE_uACNn5k9-6wE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xb543c9d8b44868fe6f3cc267ccc6206fbccb72aef2eb03d3d30053ad3009d30d".hexToBigInteger(),
                 s = "0x6724cc6234f2a2dafdde5dcb1a38dace720d623c27681f0a9cb920ee88e88309".hexToBigInteger()
             )
@@ -133,7 +133,7 @@ class SignatureTests {
             address = "0xcccbc15856de1c89fc7dd2199e0fd307619224bd",
             jwtSig = "2_ddtzVB6tRanvkqWWdet7mzr8pf1kOXbAGvYAwS1O-jsE20rM8ezMQAyFEifoB5cObeyZagiphadDyjvFEaEgE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xedaa5487d69116782df792834025bfc1e25537a218596515b081a6f93460a0bf".hexToBigInteger(),
                 s = "0x7e8f7bc0d58b0dc8d6cfa51cf4bbe1fe587d92e1fab8f003184c3da37a322924".hexToBigInteger()
             )
@@ -143,7 +143,7 @@ class SignatureTests {
             address = "0x2860b31d01c27ee58b65c9cfa96a66428452209d",
             jwtSig = "DDN1d4Lk0-Bq1JKs90ToO6f7gw9u9K6m_fUvPT5ENvIIDm_6KI_M0FFSf02YS7-HOl1mvlHwGAyR-ommaCNpFAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x19d6f2aa28b5a3292953d476b1b80b7ddae701abaf42b6d50d0be49058638b25".hexToBigInteger(),
                 s = "0x7b7e1daa4f2b2ca41844ac2e24a53398f6621bd212ee565bbe111cd640a26a0f".hexToBigInteger()
             )
@@ -153,7 +153,7 @@ class SignatureTests {
             address = "0x45e7dffad61bb58639de09d8e2f82af7a4b567ce",
             jwtSig = "sqXseGUZDaoCtRC_IcO90b7zmeTMt9dvgNjx-vptsSg22b1EzS6N-DbaPEZk6z_oM2sEsWbnby-IX9JRI55zHwA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x30108b61995f50f56c5bb0ed7dae1467ace56a69176c5006249e77e918dc5ab9".hexToBigInteger(),
                 s = "0x1aafefeffc49cc372ccf0ab711d46b85ef222699ef81198d5f3b8d147e9776c7".hexToBigInteger()
             )
@@ -163,7 +163,7 @@ class SignatureTests {
             address = "0x034d9566428abf22fa1e48a61d6f0f5688108b60",
             jwtSig = "CFEcsb0s0t8HMkD4hTYoqRdtAcoIgQk0cTIyD__-FQeh6NZuIciyc49e4EcNWxtXkocPc8aZCOKA2JTnbwAZDQE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x7e732a82558d4eacddb07cb154cd80ab5eb69b63ecd3b2dffbe9ce99607cbad4".hexToBigInteger(),
                 s = "0x5ff236a1e206ff4e1146ab752fa767b253a4b2741d05a7da748d9843a2755a19".hexToBigInteger()
             )
@@ -173,7 +173,7 @@ class SignatureTests {
             address = "0x51396c5f444b6ef5fc81733a7526d281c083d201",
             jwtSig = "Y-5l1cPkJElpCS8N5tBMnlSGO4rCKS4L4-Wo0ei9Wvz5_2fER_lMApxm87ROv_hsxWpEeA3lUlgoI61f6kj14gA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x75d98a10162bc8af835b5361050733dc71d2ea3d89718e74c761bc09e6aaf764".hexToBigInteger(),
                 s = "0x4ece672fc2f5fb78a5828ed66ebb8cb03fb8d9e290e8dc5ce8a55e1dfa84574".hexToBigInteger()
             )
@@ -183,7 +183,7 @@ class SignatureTests {
             address = "0xdaa1c0545800dc929dea802d5dfda4023938671d",
             jwtSig = "O3OPhOHNcHiqZ8lJQL9TsiO7zyOHU7Th3QZlnqtSAqFGglcDNGJJs0pTZBuybMt6tLohgGXCUiawcy68jvHOKAA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x8cfe724b4d0b389001cbb953300ede523214627cec21f1acac636c39731de29b".hexToBigInteger(),
                 s = "0x7724a066d7aec63dde0fc5a8066d0e1007fa593b5df044c592ebefd37cec4227".hexToBigInteger()
             )
@@ -193,7 +193,7 @@ class SignatureTests {
             address = "0x2192896ae7d442b6f5b9b4eb2d62c68b64be9b7c",
             jwtSig = "lIzyO31ZgS41CTBseyzFA7MKEqi_FIP2MJPg8wyuaVoPYvNwmPCbqTftfyYwv3DjDQKovys2-Wa6KiPiXs1ScAE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x5b19a30bbd70d8d0732cb6776736a979859e1cd093eba63da0b21262617e6e47".hexToBigInteger(),
                 s = "0x348bcbaa52eb0a9b5f9ae40db4ecbb93d65414fbdc1318b7ec97311688381775".hexToBigInteger()
             )
@@ -203,7 +203,7 @@ class SignatureTests {
             address = "0x53dda7b3f76353a12c4330419edd002a40f6d264",
             jwtSig = "SvfCtPcL_-i1760xXWP8AE8BEhEXvCTn6hbawf9kBIHIdiWiqz9uWoEobN5-3ma1Mjem7-zUgOvHV-qQ8ZbuVwE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xf88674f90b28d1958f92d463f69f1c5f0334bca7f2cb5f402a5eed91ac99d6ea".hexToBigInteger(),
                 s = "0x3dcb3701775738c8761afdbaa846ea14a90a8e16bc1cf11b53fbe3253cefa2ba".hexToBigInteger()
             )
@@ -213,7 +213,7 @@ class SignatureTests {
             address = "0x33e76ac20f2c2968736a511ab951ca5f1d3c91dc",
             jwtSig = "OAjf7G2JK2j-KRjL8axKOaQL4sb3z_N2LvsaX7wZewqrkUL9arKTv2is1FF_gsi5yJkHbVjJcT6VwW-NfWRpTwE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x75368b17f89da28918f8e9e8255d458fe6179d8e6cb1e03023ec791692befa43".hexToBigInteger(),
                 s = "0x5a3fa448450572e5cca045868c5710cbf9abfb5477e17a33841ee899dba838cd".hexToBigInteger()
             )
@@ -223,7 +223,7 @@ class SignatureTests {
             address = "0xf10c10a877bf48cd6e165e598420d184d545c710",
             jwtSig = "mXooezXiSupDRnkg04HMu4rxljwa7jnhEhDQPOr3QKacmygDhq0YUQWwyKViyrbhsyYNLQmrOfHe8CaERUhexgA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x6f5131247445078a700ad20d4f709d0fa3c5d01926108ffa8a418e7201bd5d70".hexToBigInteger(),
                 s = "0x1a9a191fead29cd1e8bd333c4ff419a19ba715f6b123dde04e610b784a707eef".hexToBigInteger()
             )
@@ -233,7 +233,7 @@ class SignatureTests {
             address = "0xedd67644082494a750f27cd88bbf1a71cf924c97",
             jwtSig = "kgjSiYtYE3YymfKMiZywD_c_nMRHhiyL-gTpoNXsaq2nNFuueIiWRwAYY1X2ZHl8mBMr__Ume_mQT-MAvaQSywA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x63a9677f3515ec3fafa712d6beb7ca394e9e17800b5f7b0ef97397b3af4583b2".hexToBigInteger(),
                 s = "0x7dcac086cb224f70728e4ec45b45f395e03e521804d7806b1ea81e85063f3d68".hexToBigInteger()
             )
@@ -243,7 +243,7 @@ class SignatureTests {
             address = "0xacc258d24cf3bcce696970d82704b13651aa5110",
             jwtSig = "gTskEAgYVe_pBEG2U9jA7U82gxIZLGxLV__m46KZO-fo-RIeEguk4kSeJft5MjuZXhyLkLxp3IDpihM8m99hwAE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x52211fd7673e9cec76ab02000bcbb9c27c34733c5c07fb0f3b6d7966dca94fea".hexToBigInteger(),
                 s = "0x316310a4700aab7f43b1b12c0750066fe8439cdd6013c6dc0b67ce0e3688de4e".hexToBigInteger()
             )
@@ -253,7 +253,7 @@ class SignatureTests {
             address = "0x4c17ca8cc38ed5c6828085004d98dac7c1a88ca9",
             jwtSig = "CcZq5_7Yv1UHJ_IkERzDL8hwDxZNd2hIAuQckvkuQWVFh9o8N4-aVxU5jLFGbMR4eNNhHwl4Q0PgeAads4sWOwE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x14dcf1690f676539e564e8d8d2aca652fbcb2a177c832ea526e8fb6f02240c52".hexToBigInteger(),
                 s = "0x28cd38406e48d11cea6f997d7fbfac8facdb47f3ee8ae6ce06d4d6120da60fe0".hexToBigInteger()
             )
@@ -263,7 +263,7 @@ class SignatureTests {
             address = "0x5e120e24884dcd7f575a284ca3e9cbf9db70fd19",
             jwtSig = "foeD4MInXaqrQFwFS8fu0e8Od-2wQ6YNRNAtHcmTg3YnOgXtwpZ9b50TskVdVh4B6ortcz2fenVHHET6Deo7-QE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x3b752a6d51a97b4e860eb04cd4a30ed40b1c8b686ad2e707379329cd91c3b9fd".hexToBigInteger(),
                 s = "0x186752e5fbe99427164eecdf419e2ce2cc09bbd873b4f679270ce7f9ae54c3db".hexToBigInteger()
             )
@@ -273,7 +273,7 @@ class SignatureTests {
             address = "0xf087ac18893f337cc6c4f3392ac02cf36ed29b21",
             jwtSig = "6vqOMUbEvEohSHucATLZOClqtR5XbfSVAvcO77ryoezGHKA51TtYAwFuP-CYjIBiCrN2BqiDCat9BEYpW-WoLgE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x178f3c0163c3e2cadf8a689a17aa1e7057ebc12017c1120c6c33410daa45ad58".hexToBigInteger(),
                 s = "0x33f9ed16853fbe17cb3451ab654845c1df9627e010be5036ee6338b55a95758a".hexToBigInteger()
             )
@@ -283,7 +283,7 @@ class SignatureTests {
             address = "0x7ba6f7ec98a081e00a4b4ea6d4608600a2140860",
             jwtSig = "UVWK8Fj0_UCYOX5k054VDieDqjNyMEDqU9z7sR1pBlEkcnNHSPTy-_yERivs256JF6agLvUpkbEft8bM9SWRTAA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xdbe1785b2a44cbf40b6ad177b015b8ce655669d0778393f97f487951e18afc59".hexToBigInteger(),
                 s = "0x1f523e375fd7dc1be2ac81c38526820dc830b2ef675fb623118db76e176b50e9".hexToBigInteger()
             )
@@ -293,7 +293,7 @@ class SignatureTests {
             address = "0x5a9d02fccee8b2507820889c6a25907592b2352e",
             jwtSig = "UMku-ulQQMyhJIsKfyTxIEe7_HV5k7IApDl8VtuPnnktbmoqFVdIbMNFarr15GYt-IoA125oQLP9Bo23OU_q6gA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x70a5309837a51d3729642736152249a302ab44362914db524aa2f6938e951f42".hexToBigInteger(),
                 s = "0x3f713c016cc77147aef275e6065cda248a265adb8865cdce54cf6a9b15093921".hexToBigInteger()
             )
@@ -303,7 +303,7 @@ class SignatureTests {
             address = "0x94c43da2c7fb4986925ce2a3cc2adb4be42457de",
             jwtSig = "CTlw7KDH6Pwt1mAeNbR1ePaQ06dv96NreO5Es7b4L8L4TP31vsupZWsiBSeOQ6m71TapkgyTOgpavNXF1wbYAAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xd463b31c71e24192241c2a7ef84e550d0fa07e9c4716fe58b4891c9648541f87".hexToBigInteger(),
                 s = "0x5ea77ea6d57dfd0a681eff19fe2af99950ac701616bc911efc4e004bd9d413f1".hexToBigInteger()
             )
@@ -313,7 +313,7 @@ class SignatureTests {
             address = "0xd07eb4161cd20716e7756d37d6ac0d2e851ea3dd",
             jwtSig = "vQTFP2H24XMthwRsd80Hxh_7GnaGeLAGWSUw0pEz3SfSaYbtdGUOefXEsdEBrvYXVSseQQr1VIGUc_hZ8j6rPAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xc803f137c8fca3fa681d7fd34e02319bd1a059109d5fe0f9d3bc369c3586c9f4".hexToBigInteger(),
                 s = "0x7c15dd8513ba5f6c1125522ff5c6f0945805936d9787657ece73828cc6fc9c22".hexToBigInteger()
             )
@@ -323,7 +323,7 @@ class SignatureTests {
             address = "0x47221e33c828259edbebf4cde1e57bf09224fe7b",
             jwtSig = "npBfIb-pGeG_JrEXjmDJrBWMa7SroSoPBqbAsuHC-yZjFFOBNuhoOc6nAJzRvtoGRH_oT7LXz_bqdoIVb2KglAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xe003a9fa1fd6588614c8296cb74ca9c77ca8b314c552f850d750acf790289908".hexToBigInteger(),
                 s = "0x3db1afbe3c70d47f06c2e9802978d772722ecfa537e6c7006b5586fdef4e4db2".hexToBigInteger()
             )
@@ -333,7 +333,7 @@ class SignatureTests {
             address = "0xc7f2b6ce3c775d0e011c77a978ea1713c17e314e",
             jwtSig = "1s6QCrFtWOghTRreZqimcJGqLob3dYq-fPOV7YBu4DmPiGdOZeF7aVOVh2mnPiKChdCWyws71t8Q4kcbn4KOvQA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xf13d2b58e85851d5c327ace636df9e66b70cfb4db7b6994913a312f8cd6fb52".hexToBigInteger(),
                 s = "0x7607e1d1d86a3ccf90c9e4e0f13471fe8f7d60b405968a693fb20ab3a765e48a".hexToBigInteger()
             )
@@ -343,7 +343,7 @@ class SignatureTests {
             address = "0x8183a72d9163f19400bf4243de3d2307e42044d8",
             jwtSig = "2S3X-IburN8P5uuaDuZkLs4KpMKkxhF3a20mtV1NJ0Q1liWt1h5x4zw9owN9clYpor5jBZgYAua9Gl7neaTkyAA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x2bdfd7aaaed275426cac0a3d84947b4fdbcdbf3b6420f4f11b755e34d9aab454".hexToBigInteger(),
                 s = "0x6846282eaa5daa9769e7e45671d07893b9e4a50ae55c755f472747e0d7096d06".hexToBigInteger()
             )
@@ -353,7 +353,7 @@ class SignatureTests {
             address = "0x64ed433519e8c99c990104e5feecca360e88ad67",
             jwtSig = "OQQuRn2m5NFVgm7OVL9amcr1rvfuOe6dv9ojul-PGOLWbqS5N_sFiiSbckrZXBElWcYe9NR6iULMEfFJ_aP0rQE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x27b9e2b405c16171464f2de3c03f2590cd66e4397d13463a7d498bbe716783f".hexToBigInteger(),
                 s = "0x2c04841b252e9277b97dce5d2f5c3e097f5a8830b9614b7ede82ac839b460045".hexToBigInteger()
             )
@@ -363,7 +363,7 @@ class SignatureTests {
             address = "0x8da5e4f050638e59e87bba9ecd2cb1e6daac777a",
             jwtSig = "NfR8hmJDpwTjq0zUl4hql2t69AwiMXFSiA6jxDzoa4wLX-5o957Cryw0hUuX9qAqtw8AbMCvVJCiYe7LId3NqQA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xcf4974379001999c10c123211e1e07859a10175360babd9d0278211051d8278e".hexToBigInteger(),
                 s = "0x157c9625b3b59cfdc281948b3d8c8b537d365b1c511d72a2ef4d15f9bcb4f4c".hexToBigInteger()
             )
@@ -373,7 +373,7 @@ class SignatureTests {
             address = "0x0e899ed45a65b7df769409ad7b4022a88ba6e88d",
             jwtSig = "i5H24fGipgB3uqKFybinTShghtVWXSDzLZgC7xv-OtDkkakkHXL0z-9zYv6CultHF4H7AokfR2jm-XEojVi9vQA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xe1fa66ba41b1600155d641f7ca87ef420aeac054941eb4d57a111030f0e4cc92".hexToBigInteger(),
                 s = "0x63c692f926d917e7c1780d358c53d7e7c3ec7e829a090f1ccb872ca7417224bb".hexToBigInteger()
             )
@@ -383,7 +383,7 @@ class SignatureTests {
             address = "0x2cfdba50cef4740afb6653637b9753e157013ab9",
             jwtSig = "iOYwRCk49OhKhfpE9ToUdSnhnsT7kW9yJeQ6q-qN7kO8AkKh5_HvoJBnSem6Ttqls8kEjF-mcyTyBtvkTwJR6QE",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x5b9fb7ad028a8d1192f6bfa9a282b97bb5142c333a255d77c8078ff5bbe3f3fc".hexToBigInteger(),
                 s = "0x403f0b223d83cc6303297e4d60fbdde07e0f7881f1446af6267657f732ca44fe".hexToBigInteger()
             )
@@ -393,7 +393,7 @@ class SignatureTests {
             address = "0xc7567e2839190e618979a2e0ccd29a1b661b0901",
             jwtSig = "-cyEBJEWjUYabyTJNi6rn7sDCIniKtlftxxoQmyuJEUE47o3nMAgfFALLoEH0NF1VuzzLyPoQmaRdrp5iZjrJgA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xb8fda60c66ea89af5d0285bc4c3c49017eb457a89f1d97b89cee9ff4cecb1d6".hexToBigInteger(),
                 s = "0x551674a7f205692573a81c5996898bfa721bee4509136f247ce0ea5bc110604".hexToBigInteger()
             )
@@ -403,7 +403,7 @@ class SignatureTests {
             address = "0xf8484190e003797a21eb2b522b0e7f3545bc5c98",
             jwtSig = "_-evI1296bUxUinbixLgfim-27QrMDo1HCOwmJd1cOH0Q2BL31F0mx--3rDvK9xbz3kIPNGGUBXhial_MnPxdwA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x933cb61ffd3efd43b2caea2d6b3d97b62e24c24a891dbbe96a0fb49e11980938".hexToBigInteger(),
                 s = "0x98bc22f8f8db8f49b58fe45ba503a14cecc5ec75b20237e13c3d488d3cfba4c".hexToBigInteger()
             )
@@ -413,7 +413,7 @@ class SignatureTests {
             address = "0xe694d6bfb0e0f60e047f37790f0bbf2e3a78352c",
             jwtSig = "otDw4UATSRxEQl45M16cHez3AEIm4Vz_QZg8uy5zddqRO2kX49M8enr3yjsLVuRkE0cqH4W6nfu4tSRJb847kgE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x90aeaa277adfa752533819651261f38b23f23f368349cbbf52a6292db688c33b".hexToBigInteger(),
                 s = "0x1ea00142834b6b9685eaca6998f5aea0a16b3d0b6d31a465b0ac798f9250da62".hexToBigInteger()
             )
@@ -423,7 +423,7 @@ class SignatureTests {
             address = "0x769952b356819d8e1ab63312d5ac3c2c14d1801e",
             jwtSig = "xWUEZjxun0i2DpZ49uJKSlCAkZw_bkGRbU-PElF4r_0I0dP6DAJa_dd_c0VLmyZadeKNaaCssi4bJNnTY4vlDgA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x8beb76acec1919989aa287af3bd7ed228fa042a8d13ecc84e06eec735c798eb2".hexToBigInteger(),
                 s = "0x7c8c5f26bd3eacdcc6ac938a0b35f9a3afe88636280ba0ea391a68a957c8f21f".hexToBigInteger()
             )
@@ -433,7 +433,7 @@ class SignatureTests {
             address = "0x4edd332bd5aabc51a7305f8c0b6220a3ce438c83",
             jwtSig = "Rknuj10koIStG1Yj7ePzsaM3LIUlECK1O_oW3CsMbbHwfUK5LemfliZBGHAsyY-l_IeTRVucwlldc-W59Xui3wE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xcd0682b37003064536d421dad51d5af1ee79c08d84ea6e4a939ce631923d266d".hexToBigInteger(),
                 s = "0x59a17d5675bb7473e5a6f5c2bacd3fab6c804a0fcac5737f4a0b2201074be914".hexToBigInteger()
             )
@@ -443,7 +443,7 @@ class SignatureTests {
             address = "0x2a5c2ae9941f4cedb047289e2b9f3357b16baa0c",
             jwtSig = "5JAjO5oKXaZUkQ8Ae6SmyVTP4lIBm4k2KNnzcwfbhylXzC6PbrX2aPm6YfaTU0ZyghMFLFOw6ElOMuOmMH3jswA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x7ca586033f4cbb3cf4a7fd96432c31db059a2ba9405c09d0aec7582ea55270d4".hexToBigInteger(),
                 s = "0x4041e8c8f8146f5bbdbbda2a41c73d97978a06307a6071459ac5effd309eebcb".hexToBigInteger()
             )
@@ -453,7 +453,7 @@ class SignatureTests {
             address = "0x44ab6c23c05f227447196356d7a8ba8f5f5ccfd0",
             jwtSig = "q9X7DkW2nNxhBUDhb8h-wfQ8yDEu49WZjvQbeHCusPPSVGc6IeRiDIgPyAuqjQ7TheNVQwXfjDYZNn34MIZx-wA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0xdc79780b9cfd68759eab3985a01e11a84b2569a4c0ccd7c56e3295a15d8f3aa0".hexToBigInteger(),
                 s = "0x282acdb462bb5efd03b0d800b098eb23e195b0c1a56dfac0b9f08431bc7c6792".hexToBigInteger()
             )
@@ -463,7 +463,7 @@ class SignatureTests {
             address = "0xfcaee7e3d0786365eb2917d3bb1fa6392444387a",
             jwtSig = "w1V0LeVBDhTC5nOB65a8SJzM5_Z5_jJkJZZVE0G64RPLIE1SYCSeF2wFDBNmSHZBAX5MQPMyjV3POkNVLvfs5gE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x2515c84688364987ae74c22594c083b71676f244de34660f180b95b7d71cc5a3".hexToBigInteger(),
                 s = "0x21c03e55e2f934ae81b88bdffe1c325c00d62b3cd37f489097f2281855b38e8d".hexToBigInteger()
             )
@@ -473,7 +473,7 @@ class SignatureTests {
             address = "0xde3700766d266524bfb1bc0d8d5e077fb6f65a42",
             jwtSig = "lqSEFF-Mv3uQhB-Swx9yRgK1Cp5V77LLTKi9b9-opZpCOsapzjH8GzMgNnNUEJcO-EvF40_hlxzWykz3pm4qHQA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xdc38c256b289830b45c941d1ae89dd623936ddb0e3120a89011f811c80d8338f".hexToBigInteger(),
                 s = "0x573433304a723b9c97830c05075a051b5bd314da7f38c753eba8ae43550d49c8".hexToBigInteger()
             )
@@ -483,7 +483,7 @@ class SignatureTests {
             address = "0xc92a4bbb46f48fed7cd154a71afa755732e460eb",
             jwtSig = "wzCVKbqYbNmeyFNN86TrlLESCh8q4pUZl7FqaW38DY50a3J_N7_1QVUrUTO6Nof-cpfl3gR3KqBz4ejTHWBCEgA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x6010e460863239ef329ea76ab26219505a4672d72bb9f31e35080b163bcb6721".hexToBigInteger(),
                 s = "0x62cd62aa206eda51076c36e7f76c712df58f0eeed7c9286d532197aa0003e50c".hexToBigInteger()
             )
@@ -493,7 +493,7 @@ class SignatureTests {
             address = "0xb8489af2cb572304c607f14c991efa83517da888",
             jwtSig = "Y03oDOsmltbseap8QuIUFM_lDzu2o7QolEXxwV5tlArlhxO9mAzcLSM7zJKYz0L74cPZoQiMiZaeKM1ohYgz0QE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x596e4048cbf970cad7a3de08da7a8e0070d3eb202b906e3e662f7f557efa2464".hexToBigInteger(),
                 s = "0x396c2e34c43f9e49e67dc601c6c408a4b7cf757fd2c0efd18596641559512efb".hexToBigInteger()
             )
@@ -503,7 +503,7 @@ class SignatureTests {
             address = "0xe398a7b24b6931ff34b557ae14db3117dd51fbc7",
             jwtSig = "2WH02NgmsZgPawIKXTLsz99JqTiyrQ2FXsNJBwyMNkQ3_XTK-tqc6BMU3XP2mg2CXs2RHEZSwn1GnJfP1VOomQE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x30370d3c46e8d94cd525e6a1d08567a7e084262ae4add7d0d9769dd826b7490c".hexToBigInteger(),
                 s = "0x3762be0566440c2f15efac351e79cbe8614aa875b7bd1b547fec32add7ac0ec1".hexToBigInteger()
             )
@@ -513,7 +513,7 @@ class SignatureTests {
             address = "0xd972ed893a96444bd27ac6e21d8de4f12608e4d4",
             jwtSig = "ZwnD-zdlXtmclgb4kxwrHjghiu_RiNAhvpcMtBg4dD2Tif60MCeg7Gf0LVbhnt-MWoHXDD0BKKqurawzAaTV0wA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0xc7f59af7313580480705c7934e3a0d1e418c5e5fa3cdabe81d67ff4fd379b48c".hexToBigInteger(),
                 s = "0x7eaf2fce318b95c3e36665f8eeea289ba8ea7ad857543ce03df13dfef2125c07".hexToBigInteger()
             )
@@ -523,7 +523,7 @@ class SignatureTests {
             address = "0x30fde40c45959274e8da4f16e641936c492fce2f",
             jwtSig = "090Wgb_MnL1Ei5ZYwJBYTZtKx4KV2wN7Ar1r-jIl2gMWpiRgC3TztCQbxlrukAmvq9XyEmbnn8NaVDpDDEkZSQE",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x5878d68a45ca349e01a07699fcac7c690ed2c437864fa028ac61fa75685219c".hexToBigInteger(),
                 s = "0x42026e4c724048c4b77914bff56877c2b759ad2c6bf9e67b652e26afcf08b765".hexToBigInteger()
             )
@@ -533,7 +533,7 @@ class SignatureTests {
             address = "0xd4318fab9656eb478b63caf458262ca95e914e78",
             jwtSig = "yj3ebIZQQpX_TmZeKUxSzAmUib9PAAmI8DdshnrVpLDAY3eYb6rFnDtUgMf7Unz0ALXUfqvc0JFNKNDJK_WwXwA",
             txSig = SignatureData(
-                v = 28,
+                v = 28.toBigInteger(),
                 r = "0x37708864d23409b99adc7bf21703638fec1396ddc574c1ea1204e43c9c630be7".hexToBigInteger(),
                 s = "0xa20e127564ebc955d32c5bdf19d3711c34596bfde79c38152c8267080b9c033".hexToBigInteger()
             )
@@ -543,7 +543,7 @@ class SignatureTests {
             address = "0xde7c3bffe1205adc8c2dd654ecf8dece33efdb54",
             jwtSig = "-99We6jDdOZwfYj_1N1a5VCX-X1brrcKRKZbG5LQDhYTU_2ObTuBRBU5gk0zG7hb5yizZiYUR0CS1y3Zt0H-yQA",
             txSig = SignatureData(
-                v = 27,
+                v = 27.toBigInteger(),
                 r = "0x416bf6c393266b9467726049b2dd54b01b40f08c16255e1423d57d02a11372a2".hexToBigInteger(),
                 s = "0x3d9ad2f56843a1c841787e83aa50a09ea6f6b479888c86639bcf80bf42f1affd".hexToBigInteger()
             )


### PR DESCRIPTION
### what's here

This is a maintenance PR
* update the kethereum dependencies to v0.76.1
* adapt imports to the new version
* clear unused dependencies

### Testing
All existing tests pass

### Note

This is a breaking changeset and will have to trigger a major release.
This is because of a change in the kethereum data model for `SignatureData`. The `v` parameter is now a `BigInteger`
Also, each module is now isolating the implementation details, no longer exposing dependencies upstream.