### PR TITLE
Fetch network using name

### DIFF
--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -136,7 +136,7 @@ object Networks {
      */
     private fun getNetworkByName(name: String): EthNetwork? {
         for ((_, value) in NETWORK_CONFIG) {
-            if (value.name.toLowerCase() === name.toLowerCase()) {
+            if (value.name.toLowerCase() == name.toLowerCase()) {
                 return value
             }
         }

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -135,12 +135,8 @@ object Networks {
      * Searches for an [EthNetwork] based on a [name]
      */
     private fun getNetworkByName(name: String): EthNetwork? {
-        for ((_, value) in NETWORK_CONFIG) {
-            if (value.name.toLowerCase() == name.toLowerCase()) {
-                return value
-            }
-        }
-        return null
+        val queryName = name.toLowerCase()
+        return NETWORK_CONFIG.values.find { it.name.toLowerCase() == queryName }
     }
 
     private fun cleanId(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -121,13 +121,26 @@ object Networks {
     }
 
     /**
-     * Gets an [EthNetwork] based on a [networkId]
+     * Gets an [EthNetwork] based on a [networkId] or [name]
      */
-    fun get(networkId: String): EthNetwork {
-        val cleanNetId = cleanId(networkId)
+    fun get(nameOrId: String): EthNetwork {
+        val cleanNetId = cleanId(nameOrId)
         return NETWORK_CONFIG[cleanNetId]
-            ?: NETWORK_CONFIG[networkId]
-            ?: throw IllegalStateException("network [$networkId] not configured")
+            ?: NETWORK_CONFIG[nameOrId]
+            ?: getNetworkByName(nameOrId)
+            ?: throw IllegalStateException("network [$nameOrId] not configured")
+    }
+
+    /**
+     * Searches for an [EthNetwork] based on a [name]
+     */
+    private fun getNetworkByName(name: String): EthNetwork? {
+        for ((_, value) in NETWORK_CONFIG) {
+            if (value.name === name) {
+                return value
+            }
+        }
+        return null
     }
 
     private fun cleanId(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()

--- a/core/src/main/java/me/uport/sdk/core/Networks.kt
+++ b/core/src/main/java/me/uport/sdk/core/Networks.kt
@@ -136,7 +136,7 @@ object Networks {
      */
     private fun getNetworkByName(name: String): EthNetwork? {
         for ((_, value) in NETWORK_CONFIG) {
-            if (value.name === name) {
+            if (value.name.toLowerCase() === name.toLowerCase()) {
                 return value
             }
         }

--- a/core/src/test/java/me/uport/sdk/core/NetworksTest.kt
+++ b/core/src/test/java/me/uport/sdk/core/NetworksTest.kt
@@ -40,6 +40,36 @@ class NetworksTest {
     }
 
     @Test
+    fun `can find a registered network using the name`() {
+
+        assertThat(Networks.get("mainnet")).isEqualTo(Networks.mainnet)
+
+        assertThat(Networks.get("rinkeby")).isEqualTo(Networks.rinkeby)
+
+        assertThat(Networks.get("kovan")).isEqualTo(Networks.kovan)
+
+        assertThat(Networks.get("ropsten")).isEqualTo(Networks.ropsten)
+    }
+
+    @Test
+    fun `throws error if the network name does not match`() {
+        assertThat {
+            Networks.get("manet")
+        }.thrownError {
+            isInstanceOf(IllegalStateException::class)
+        }
+    }
+
+    @Test
+    fun `throws error if the network name cases does not match`() {
+        assertThat {
+            Networks.get("Mainnet")
+        }.thrownError {
+            isInstanceOf(IllegalStateException::class)
+        }
+    }
+
+    @Test
     fun `getting an unknown network throws`() {
         assertThat {
             Networks.get("0x1badc0de")

--- a/core/src/test/java/me/uport/sdk/core/NetworksTest.kt
+++ b/core/src/test/java/me/uport/sdk/core/NetworksTest.kt
@@ -52,18 +52,14 @@ class NetworksTest {
     }
 
     @Test
+    fun `can find a registered network using the different case name`() {
+        assertThat(Networks.get("MainNet")).isEqualTo(Networks.mainnet)
+    }
+
+        @Test
     fun `throws error if the network name does not match`() {
         assertThat {
             Networks.get("manet")
-        }.thrownError {
-            isInstanceOf(IllegalStateException::class)
-        }
-    }
-
-    @Test
-    fun `throws error if the network name cases does not match`() {
-        assertThat {
-            Networks.get("Mainnet")
         }.thrownError {
             isInstanceOf(IllegalStateException::class)
         }


### PR DESCRIPTION
#### What's Here

To support retrieving network using either the network name or id, the following was done

1. Created a new private function to iterate through the registered networks for a name match
2. Added the function above the the `Networks.get()` logic
3. New tests to verify searching with name works fine
 